### PR TITLE
add default shutdown/restart

### DIFF
--- a/multi_switch.sh
+++ b/multi_switch.sh
@@ -145,6 +145,9 @@ function es_action() {
                 kill $ES_PID
                 wait_forpid $ES_PID
                 exit
+            else
+                shutdown -r now
+                exit
             fi
         ;;
 
@@ -156,6 +159,9 @@ function es_action() {
                 chown pi:pi /tmp/es-shutdown
                 kill $ES_PID
                 wait_forpid $ES_PID
+                exit
+            else
+                shutdown -P now
                 exit
             fi
         ;;


### PR DESCRIPTION
I noticed when emulation station was not running the script would not shutdown or restart.  I have added default behavior to the logic that will initiate standard shutdown and restart commands.